### PR TITLE
Add Google reCAPTCHA to contact form

### DIFF
--- a/components/Home/contact.tsx
+++ b/components/Home/contact.tsx
@@ -1,5 +1,5 @@
 import { Controller, useForm } from "react-hook-form";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 import { Input } from "../Input";
@@ -15,6 +15,9 @@ type FormValues = yup.InferType<typeof schema>;
 const Contact = () => {
   const [loading, setLoading] = useState(false);
   const [sended, setSend] = useState(false);
+  const [captchaToken, setCaptchaToken] = useState<string | null>(null);
+  const recaptchaWidgetId = useRef<number | null>(null);
+  const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
   const {
     handleSubmit,
     reset,
@@ -23,32 +26,107 @@ const Contact = () => {
   } = useForm<FormValues>({
     resolver: yupResolver(schema),
   });
-  const onSubmit = (values) => {
-    setLoading(true);
-    fetch("/api/send", {
-      headers: {
-        "Content-Type": "application/json",
-      },
-      method: "POST",
-      body: JSON.stringify(values),
-    })
-      .then((res) => res.json())
-      .then((data) => {
-        setLoading(false);
-        if (data.error) {
-          toast.error(
-            "El envio falló. Puedes intentarlo más tarde, o contactarme a daniballesteros@protonmail.com"
-          );
-        } else {
-          setTimeout(() => {
-            setSend(true);
-            toast.success(
-              "Tu mensaje fue enviado! Te responderé lo antes posible"
-            );
-            reset();
-          }, 1500);
+  useEffect(() => {
+    if (!siteKey) {
+      console.warn("Falta la variable NEXT_PUBLIC_RECAPTCHA_SITE_KEY");
+      return;
+    }
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const loadRecaptcha = () => {
+      if (!window.grecaptcha || recaptchaWidgetId.current !== null) {
+        return;
+      }
+      recaptchaWidgetId.current = window.grecaptcha.render(
+        "recaptcha-container",
+        {
+          sitekey: siteKey,
+          callback: (token: string) => {
+            setCaptchaToken(token);
+          },
+          "expired-callback": () => {
+            setCaptchaToken(null);
+          },
+          "error-callback": () => {
+            setCaptchaToken(null);
+          },
         }
+      );
+    };
+
+    if (window.grecaptcha) {
+      loadRecaptcha();
+    } else {
+      window.onRecaptchaLoadCallback = loadRecaptcha;
+    }
+
+    const scriptId = "recaptcha-script";
+    if (!document.getElementById(scriptId)) {
+      const script = document.createElement("script");
+      script.id = scriptId;
+      script.src =
+        "https://www.google.com/recaptcha/api.js?onload=onRecaptchaLoadCallback&render=explicit";
+      script.async = true;
+      script.defer = true;
+      document.body.appendChild(script);
+    } else if (window.grecaptcha) {
+      loadRecaptcha();
+    }
+
+    return () => {
+      if (typeof window !== "undefined") {
+        window.onRecaptchaLoadCallback = undefined;
+      }
+    };
+  }, [siteKey]);
+
+  const onSubmit = async (values: FormValues) => {
+    if (!siteKey) {
+      toast.error("El formulario no está configurado correctamente.");
+      return;
+    }
+    if (!captchaToken) {
+      toast.error("Por favor confirma que no eres un robot.");
+      return;
+    }
+    setLoading(true);
+    try {
+      const response = await fetch("/api/send", {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+        body: JSON.stringify({ ...values, token: captchaToken }),
       });
+      const data = await response.json();
+      if (!response.ok || data.error) {
+        toast.error(
+          "El envio falló. Puedes intentarlo más tarde, o contactarme a daniballesteros@protonmail.com"
+        );
+        return;
+      }
+      setTimeout(() => {
+        setSend(true);
+        toast.success(
+          "Tu mensaje fue enviado! Te responderé lo antes posible"
+        );
+        reset();
+      }, 1500);
+    } catch (error) {
+      toast.error(
+        "El envio falló. Puedes intentarlo más tarde, o contactarme a daniballesteros@protonmail.com"
+      );
+    } finally {
+      setLoading(false);
+      setCaptchaToken(null);
+      if (typeof window !== "undefined" && window.grecaptcha) {
+        if (recaptchaWidgetId.current !== null) {
+          window.grecaptcha.reset(recaptchaWidgetId.current);
+        }
+      }
+    }
   };
   return (
     <div className="sm:w-[400px]">
@@ -98,6 +176,7 @@ const Contact = () => {
               </>
             )}
           />
+          <div id="recaptcha-container" className="self-center" />
           <div className="flex justify-end">
             <button
               type="submit"

--- a/pages/api/send.ts
+++ b/pages/api/send.ts
@@ -1,42 +1,80 @@
 import { VercelRequest, VercelResponse } from "@vercel/node";
 import nodemailer from "nodemailer";
 import Joi from "joi";
+import axios from "axios";
 
 const schema = Joi.object().keys({
   name: Joi.string().required(),
   email: Joi.string().email().required(),
   message: Joi.string().required(),
+  token: Joi.string().required(),
 });
-export default (request: VercelRequest, response: VercelResponse) => {
+
+export default async (request: VercelRequest, response: VercelResponse) => {
   const result = schema.validate(request.body);
   if (result.error) {
     response.status(402).send({ error: true, message: result.error.message });
-  } else {
-    (async () => {
-      let transporter = nodemailer.createTransport({
-        service: "gmail",
-        auth: {
-          user: process.env.USER,
-          pass: process.env.PASS,
-        },
-      });
+    return;
+  }
 
-      try {
-        await transporter.sendMail({
-          from: `"${request.body.name} 👻" <${request.body.email}>`,
-          to: "daniballesteros@protonmail.com,",
-          subject: "Mensaje de mi web",
-          text: "web message",
-          html: `
-            <p><strong>Nombre: </strong> ${request.body.name}</p>
-            <p><strong>Correo: </strong> ${request.body.email}</p>
-            <p><strong>Mensaje: </strong> ${request.body.message}</p>`,
-        });
-        response.status(200).send({ error: false });
-      } catch (error) {
-        console.log("ERROR", error, process.env.USER);
-        response.status(500).send({ error: true });
+  const secret = process.env.RECAPTCHA_SECRET_KEY;
+  if (!secret) {
+    response
+      .status(500)
+      .send({ error: true, message: "Recaptcha secret key is not configured" });
+    return;
+  }
+
+  try {
+    const params = new URLSearchParams({
+      secret,
+      response: request.body.token,
+    });
+    const verifyResponse = await axios.post(
+      "https://www.google.com/recaptcha/api/siteverify",
+      params.toString(),
+      {
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
       }
-    })();
+    );
+
+    if (!verifyResponse.data.success) {
+      response
+        .status(400)
+        .send({ error: true, message: "Recaptcha verification failed" });
+      return;
+    }
+  } catch (error) {
+    console.log("RECAPTCHA ERROR", error);
+    response.status(500).send({ error: true });
+    return;
+  }
+
+  const transporter = nodemailer.createTransport({
+    service: "gmail",
+    auth: {
+      user: process.env.USER,
+      pass: process.env.PASS,
+    },
+  });
+
+  try {
+    const { name, email, message } = request.body;
+    await transporter.sendMail({
+      from: `"${name} 👻" <${email}>`,
+      to: "daniballesteros@protonmail.com,",
+      subject: "Mensaje de mi web",
+      text: "web message",
+      html: `
+            <p><strong>Nombre: </strong> ${name}</p>
+            <p><strong>Correo: </strong> ${email}</p>
+            <p><strong>Mensaje: </strong> ${message}</p>`,
+    });
+    response.status(200).send({ error: false });
+  } catch (error) {
+    console.log("ERROR", error, process.env.USER);
+    response.status(500).send({ error: true });
   }
 };

--- a/types/recaptcha.d.ts
+++ b/types/recaptcha.d.ts
@@ -1,0 +1,19 @@
+export {};
+
+declare global {
+  interface Window {
+    grecaptcha?: {
+      render: (
+        container: string | HTMLElement,
+        parameters: {
+          sitekey: string;
+          callback?: (token: string) => void;
+          "expired-callback"?: () => void;
+          "error-callback"?: () => void;
+        }
+      ) => number;
+      reset: (opt_widget_id?: number) => void;
+    };
+    onRecaptchaLoadCallback?: () => void;
+  }
+}


### PR DESCRIPTION
## Summary
- load the Google reCAPTCHA widget on the contact form and include its token in submissions
- validate the reCAPTCHA token on the email sending API before processing messages
- add type declarations for the global grecaptcha helpers

## Testing
- CI=1 yarn build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910864db9bc8320a0f2c1b7a6003bb0)