### PR TITLE
Switch contact form to reCAPTCHA v3

### DIFF
--- a/components/Home/contact.tsx
+++ b/components/Home/contact.tsx
@@ -1,5 +1,5 @@
 import { Controller, useForm } from "react-hook-form";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 import { Input } from "../Input";
@@ -15,6 +15,8 @@ type FormValues = yup.InferType<typeof schema>;
 const Contact = () => {
   const [loading, setLoading] = useState(false);
   const [sended, setSend] = useState(false);
+  const [captchaReady, setCaptchaReady] = useState(false);
+  const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
   const {
     handleSubmit,
     reset,
@@ -23,32 +25,98 @@ const Contact = () => {
   } = useForm<FormValues>({
     resolver: yupResolver(schema),
   });
-  const onSubmit = (values) => {
-    setLoading(true);
-    fetch("/api/send", {
-      headers: {
-        "Content-Type": "application/json",
-      },
-      method: "POST",
-      body: JSON.stringify(values),
-    })
-      .then((res) => res.json())
-      .then((data) => {
-        setLoading(false);
-        if (data.error) {
-          toast.error(
-            "El envio falló. Puedes intentarlo más tarde, o contactarme a daniballesteros@protonmail.com"
-          );
-        } else {
-          setTimeout(() => {
-            setSend(true);
-            toast.success(
-              "Tu mensaje fue enviado! Te responderé lo antes posible"
-            );
-            reset();
-          }, 1500);
-        }
+  useEffect(() => {
+    if (!siteKey) {
+      console.warn("Falta la variable NEXT_PUBLIC_RECAPTCHA_SITE_KEY");
+      return;
+    }
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    setCaptchaReady(false);
+
+    const scriptId = "recaptcha-script";
+    const initializeRecaptcha = () => {
+      if (!window.grecaptcha) {
+        return;
+      }
+      window.grecaptcha.ready(() => {
+        setCaptchaReady(true);
       });
+    };
+
+    if (window.grecaptcha) {
+      initializeRecaptcha();
+      return;
+    }
+
+    if (!document.getElementById(scriptId)) {
+      const script = document.createElement("script");
+      script.id = scriptId;
+      script.src = `https://www.google.com/recaptcha/api.js?render=${siteKey}`;
+      script.async = true;
+      script.defer = true;
+      script.onload = initializeRecaptcha;
+      document.body.appendChild(script);
+    } else {
+      initializeRecaptcha();
+    }
+
+    return () => {
+      const script = document.getElementById(scriptId);
+      if (script) {
+        script.onload = null;
+      }
+    };
+  }, [siteKey]);
+
+  const onSubmit = async (values: FormValues) => {
+    if (!siteKey) {
+      toast.error("El formulario no está configurado correctamente.");
+      return;
+    }
+    if (typeof window === "undefined" || !window.grecaptcha) {
+      toast.error("No se pudo cargar el sistema anti bots. Intenta nuevamente más tarde.");
+      return;
+    }
+
+    if (!captchaReady) {
+      toast.error("El verificador de seguridad aún se está cargando. Intenta de nuevo en unos segundos.");
+      return;
+    }
+    setLoading(true);
+    try {
+      const token = await window.grecaptcha.execute(siteKey, { action: "contact" });
+
+      const response = await fetch("/api/send", {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+        body: JSON.stringify({ ...values, token }),
+      });
+      const data = await response.json();
+      if (!response.ok || data.error) {
+        toast.error(
+          "El envio falló. Puedes intentarlo más tarde, o contactarme a daniballesteros@protonmail.com"
+        );
+        return;
+      }
+      setTimeout(() => {
+        setSend(true);
+        toast.success(
+          "Tu mensaje fue enviado! Te responderé lo antes posible"
+        );
+        reset();
+      }, 1500);
+    } catch (error) {
+      toast.error(
+        "El envio falló. Puedes intentarlo más tarde, o contactarme a daniballesteros@protonmail.com"
+      );
+    } finally {
+      setLoading(false);
+    }
   };
   return (
     <div className="sm:w-[400px]">
@@ -98,11 +166,32 @@ const Contact = () => {
               </>
             )}
           />
+          <p className="text-[11px] text-right text-gray-500">
+            Este sitio está protegido por reCAPTCHA y aplican la {" "}
+            <a
+              className="underline"
+              href="https://policies.google.com/privacy"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Política de Privacidad
+            </a>{" "}
+            y los {" "}
+            <a
+              className="underline"
+              href="https://policies.google.com/terms"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Términos de Servicio
+            </a>{" "}
+            de Google.
+          </p>
           <div className="flex justify-end">
             <button
               type="submit"
               className="bg-gradient-to-t from-blue-600 to-cyan-600 text-white px-2 py-1 rounded-sm transition ease-linear hover:brightness-150"
-              disabled={loading}
+              disabled={loading || !captchaReady}
             >
               Enviar
               {loading && (

--- a/pages/api/send.ts
+++ b/pages/api/send.ts
@@ -1,42 +1,105 @@
 import { VercelRequest, VercelResponse } from "@vercel/node";
 import nodemailer from "nodemailer";
 import Joi from "joi";
+import axios from "axios";
+
+const RECAPTCHA_EXPECTED_ACTION = "contact";
+const DEFAULT_MIN_SCORE = 0.5;
 
 const schema = Joi.object().keys({
   name: Joi.string().required(),
   email: Joi.string().email().required(),
   message: Joi.string().required(),
+  token: Joi.string().required(),
 });
-export default (request: VercelRequest, response: VercelResponse) => {
+
+export default async (request: VercelRequest, response: VercelResponse) => {
   const result = schema.validate(request.body);
   if (result.error) {
     response.status(402).send({ error: true, message: result.error.message });
-  } else {
-    (async () => {
-      let transporter = nodemailer.createTransport({
-        service: "gmail",
-        auth: {
-          user: process.env.USER,
-          pass: process.env.PASS,
-        },
-      });
+    return;
+  }
 
-      try {
-        await transporter.sendMail({
-          from: `"${request.body.name} 👻" <${request.body.email}>`,
-          to: "daniballesteros@protonmail.com,",
-          subject: "Mensaje de mi web",
-          text: "web message",
-          html: `
-            <p><strong>Nombre: </strong> ${request.body.name}</p>
-            <p><strong>Correo: </strong> ${request.body.email}</p>
-            <p><strong>Mensaje: </strong> ${request.body.message}</p>`,
-        });
-        response.status(200).send({ error: false });
-      } catch (error) {
-        console.log("ERROR", error, process.env.USER);
-        response.status(500).send({ error: true });
+  const secret = process.env.RECAPTCHA_SECRET_KEY;
+  if (!secret) {
+    response
+      .status(500)
+      .send({ error: true, message: "Recaptcha secret key is not configured" });
+    return;
+  }
+
+  try {
+    const params = new URLSearchParams({
+      secret,
+      response: request.body.token,
+    });
+    const verifyResponse = await axios.post(
+      "https://www.google.com/recaptcha/api/siteverify",
+      params.toString(),
+      {
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
       }
-    })();
+    );
+
+    const { success, score, action } = verifyResponse.data ?? {};
+    const minScoreEnv = process.env.RECAPTCHA_MIN_SCORE;
+    const minScore = Number.isFinite(Number(minScoreEnv))
+      ? Number(minScoreEnv)
+      : DEFAULT_MIN_SCORE;
+
+    if (!success) {
+      response
+        .status(400)
+        .send({ error: true, message: "Recaptcha verification failed" });
+      return;
+    }
+
+    if (typeof score === "number" && score < minScore) {
+      response.status(400).send({
+        error: true,
+        message: "Recaptcha score too low",
+      });
+      return;
+    }
+
+    if (action && action !== RECAPTCHA_EXPECTED_ACTION) {
+      response.status(400).send({
+        error: true,
+        message: "Recaptcha action mismatch",
+      });
+      return;
+    }
+  } catch (error) {
+    console.log("RECAPTCHA ERROR", error);
+    response.status(500).send({ error: true });
+    return;
+  }
+
+  const transporter = nodemailer.createTransport({
+    service: "gmail",
+    auth: {
+      user: process.env.USER,
+      pass: process.env.PASS,
+    },
+  });
+
+  try {
+    const { name, email, message } = request.body;
+    await transporter.sendMail({
+      from: `"${name} 👻" <${email}>`,
+      to: "daniballesteros@protonmail.com,",
+      subject: "Mensaje de mi web",
+      text: "web message",
+      html: `
+            <p><strong>Nombre: </strong> ${name}</p>
+            <p><strong>Correo: </strong> ${email}</p>
+            <p><strong>Mensaje: </strong> ${message}</p>`,
+    });
+    response.status(200).send({ error: false });
+  } catch (error) {
+    console.log("ERROR", error, process.env.USER);
+    response.status(500).send({ error: true });
   }
 };

--- a/types/recaptcha.d.ts
+++ b/types/recaptcha.d.ts
@@ -1,0 +1,20 @@
+export {};
+
+declare global {
+  interface Window {
+    grecaptcha?: {
+      ready: (cb: () => void) => void;
+      execute: (siteKey: string, options: { action: string }) => Promise<string>;
+      render?: (
+        container: string | HTMLElement,
+        parameters: {
+          sitekey: string;
+          callback?: (token: string) => void;
+          "expired-callback"?: () => void;
+          "error-callback"?: () => void;
+        }
+      ) => number;
+      reset?: (opt_widget_id?: number) => void;
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- replace the client widget with Google reCAPTCHA v3 execution and load handling for the contact form
- add the required legal notice and disable the submit button until the verifier is ready
- harden the mail API reCAPTCHA verification by checking action names and configurable score thresholds

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910864db9bc8320a0f2c1b7a6003bb0)